### PR TITLE
fix: Dockerfile（hugoインストールのためにgoバージョンを揃える）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
-FROM golang:1.14.4-alpine3.12
+# hugoはgo1.16に対応している模様
+FROM golang:1.16-buster
 
-RUN apk update && \
-    apk --no-cache add \
-        git \
-        tzdata && \
+RUN apt-get update && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    echo "Asia/Tokyo" > /etc/timezone && \
-    apk del tzdata
+    echo "Asia/Tokyo" > /etc/timezone
 
+# install hugo
 RUN mkdir $HOME/src && \
     cd $HOME/src && \
     git clone https://github.com/gohugoio/hugo.git && \
     cd hugo && \
     go install
 
+ENV PORT 1313
 EXPOSE 1313
 
 WORKDIR /go/src/github.com/Fukkatsuso/blog


### PR DESCRIPTION
コンテナビルド時のhugoインストール中，
```
rpc error: code = Unknown desc = executor failed running
```
のようなエラーが生じた．
go1.14非対応で1.16に上げる必要があるそう