### PR TITLE
fix robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: 
+Sitemap: {{ .Site.BaseURL }}sitemap.xml


### PR DESCRIPTION
#86 の対応

手元でビルドして、Sitemap が絶対パスで設定されることを確認済み。