### PR TITLE
fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: app-engine-go
+
       - name: Deploy to GAE
         uses: google-github-actions/deploy-appengine@v2
         with:


### PR DESCRIPTION
https://github.com/Fukkatsuso/blog/actions/runs/25629110227/job/75229464300 のデプロイジョブがコケたので修正。

```
Running: gcloud app deploy --format json app.yaml --version 1 --promote
Error: google-github-actions/deploy-appengine failed with: failed to execute gcloud command `gcloud app deploy --format json app.yaml --version 1 --promote`: The component [app-engine-go] is required for staging this 
application.
```